### PR TITLE
Fix orchestrator env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 OPENAI_API_KEY=
 
-ORCHESTATOR_MODEL=openai/gpt-4.1-nano
-ORCHESTATOR_BASE_URL=https://openrouter.ai/api/v1
+ORCHESTRATOR_MODEL=openai/gpt-4.1-nano
+ORCHESTRATOR_BASE_URL=https://openrouter.ai/api/v1
 
 LANGCHAIN_TRACING_V2=true
 LANGCHAIN_ENDPOINT=https://api.smith.langchain.com


### PR DESCRIPTION
## Summary
- rename ORCHESTATOR_MODEL to ORCHESTRATOR_MODEL
- rename ORCHESTATOR_BASE_URL to ORCHESTRATOR_BASE_URL
- ensure `.env.example` ends with a newline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b3188d788322b2b3123d1f1d00c4